### PR TITLE
allow for string arrays in extra_params

### DIFF
--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -14,7 +14,7 @@ type OverwritableClientOptions = Partial<
   Pick<ClientOptions, 'logRequestResult' | 'logRequestPayload' | 'validateRequestPayload' | 'validateRequestPayloadLevel'>
 >;
 export type RequestOptions = OverwritableClientOptions & {
-  extra_params?: Record<string, string>;
+  extra_params?: Record<string, string | string[]>;
 }; // & {}
 
 export type RequestUrl = {


### PR DESCRIPTION
This is intended to be an initial draft of a PR, please feel free to completely edit / modify / discard this as needed.

https://unipilecommunity.slack.com/archives/C027QAVDQDP/p1730403441565639?thread_ts=1730393388.479469&cid=C027QAVDQDP

When trying to use `extra_params`, the types prevent me from passing in a string array

```typescript
client.account.createHostedAuthLink(
        {
          type,
          providers,
          api_url,
          expiresOn,
          notify_url: `${BASE_URL}/api/webhooks/unipile`,
          success_redirect_url: `${BASE_URL}${relativeRedirectionLink}`,
          failure_redirect_url: `${BASE_URL}${relativeRedirectionLink}`,
          name: context.user.id,
        },
        {
          extra_params: {
            disabled_options: ['cookie_auth'] // gives error Type 'string[]' is not assignable to type 'string'.ts
          },
        },
      );
```

However, when I force the types to work, the request works as expected

```typescript
 disabled_options: ['cookie_auth'] as unknown as string
```

This makes me think that we can probably just allow other types here (potentially more types, not sure what other things you'd pass in for extra_params`

