### PR TITLE
CJS Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Unipile Node.js SDK provides powerful tools to easily integrate with LinkedI
 
 # Installation
 
-Node 18 recommended
+Node 18+ required
 <br>
 
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=12.*"
+    "node": ">=18.*"
   },
   "scripts": {
     "test-e2e-clean": "jest --clearCache && jest --showConfig && jest --verbose --config ./jest.config.js",

--- a/src/package.cjs.json
+++ b/src/package.cjs.json
@@ -1,4 +1,0 @@
-{
-  "type": "commonjs",
-  "sideEffects": false
-} 

--- a/src/package.esm.json
+++ b/src/package.esm.json
@@ -1,4 +1,0 @@
-{
-  "type": "module",
-  "sideEffects": false
-} 


### PR DESCRIPTION
# PR Details
If moving forward with existing CJS implementation, these are some needed cleanup changes.

- Remove unused files package.cjs.json and package.esm.json
- Update package.json version to require Node 18+ (would recommend publishing as a 2.0.0 release as this is a breaking change)
- Updated README to mention Node 18+ is now required instead of recommended

## Other Rough Notes
This was a rough implementation of CJS in order to unblock our team. To reduce complexity in managing both module formats, I would recommend swapping to [tsup bundler](https://github.com/egoist/tsup) -- configless, leverages esbuild for faster bundles. A good read (recommending tsup) is Anthony Fu's (core team Vue, Vite) blog post [Ship ESM & CJS in one Package](https://antfu.me/posts/publish-esm-and-cjs).

The CJS migration performed also introduced another breaking change, see #13.

# Recommendations (Better Approach)
- Revert the previous CJS migration, as it includes a number of breaking changes not accounted for
  - Loses compatibility in Node versions prior to Node 18
  - Breaks type imports (see #13)
- Prepare for a 2.0.0 breaking change release with migration docs
  - Introduces CJS support
  - Removes dependencies on `node-fetch` and `formdata-node`
  - Adds type exports from root (see #13)
  - Fixes issues with SDK using FormData API request bodies
  - Closes #8 and #13
